### PR TITLE
Applied patch fixing vulnerability 57325ecf-facc-11e4-968f-b888e347c638

### DIFF
--- a/lightcrafts/coprocesses/dcraw/dcraw_lz.c
+++ b/lightcrafts/coprocesses/dcraw/dcraw_lz.c
@@ -840,7 +840,8 @@ struct jhead {
 
 int CLASS ljpeg_start (struct jhead *jh, int info_only)
 {
-  int c, tag, len;
+  int c, tag;
+  ushort len;
   uchar data[0x10000];
   const uchar *dp;
 


### PR DESCRIPTION
Filing PR here because this is the master repository for LightZone (it is referenced on http://lightzoneproject.org/)

Ref: https://vuxml.freebsd.org/freebsd/57325ecf-facc-11e4-968f-b888e347c638.html
Fix from: https://github.com/rawstudio/rawstudio/commit/983bda1f0fa5fa86884381208274198a620f006e
