### PR TITLE
Fix typo in linux launcher script

### DIFF
--- a/linux/products/lightzone
+++ b/linux/products/lightzone
@@ -37,7 +37,7 @@ else
 fi
 
 if   [ -f ${usrdir}/share/java/jh.jar ]; then        # Debian, Ubuntu
-   jhpath=${usrdir}/share/java/jh.ja
+   jhpath=${usrdir}/share/java/jh.jar
 elif [ -f ${usrdir}/share/java/javahelp2.jar ]; then # Fedora, OpenSUSE, PCLinuxOS
    jhpath=${usrdir}/share/java/javahelp2.jar
 elif [ -f ${usrdir}/share/java/javahelp/jh.jar ]; then      # Arch


### PR DESCRIPTION
This caused lightzone to crash on startup on Debian-based distros.
The path to java help had an incorrect file extension.
