### PR TITLE
Getting the size of physical memory

### DIFF
--- a/lightcrafts/jnisrc/jni.mk
+++ b/lightcrafts/jnisrc/jni.mk
@@ -118,7 +118,7 @@ ifeq ($(PLATFORM),Windows)
   CFLAGS+=		$(JNI_WINDOWS_CFLAGS)
   DEFINES+=		$(JNI_WINDOWS_DEFINES)
   INCLUDES+=		$(JNI_WINDOWS_INCLUDES)
-  LDFLAGS+=		-shared -Wl,--add-stdcall-alias -static-libgcc -static-libstdc++ $(JNI_WINDOWS_LDFLAGS)
+  LDFLAGS+=		-shared -Wl,--add-stdcall-alias $(JNI_WINDOWS_LDFLAGS)
   ifdef JNI_WINDOWS_IMPLIB
     TARGET_IMPLIB:=	$(TARGET_DIR)/$(TARGET_BASE)-implib.a
     ifeq ($(USE_ICC),1)

--- a/linux/jnisrc/libLinux/KeyUtil.cpp
+++ b/linux/jnisrc/libLinux/KeyUtil.cpp
@@ -4,6 +4,9 @@
 #include <X11/Xlib.h>
 #include <X11/XKBlib.h>
 #include <iostream>
+#ifdef DEBUG
+#include <cassert>
+#endif
 
 // local
 #include "LC_JNIUtils.h"
@@ -24,13 +27,17 @@ using namespace LightCrafts;
  * significant bit has index zero.  Used in keysToKeycode().
  */
 int indexOfBit(char c) {
+#ifdef DEBUG
+    assert(c != 0);
+#endif
     int n;
     for (n=0; n<8; n++) {
         if (c & 0x01) {
-            return n;
+            break;
         }
         c = c >> 1;
     }
+    return n;
 }
 
 /**

--- a/linux/src/com/lightcrafts/platform/linux/LinuxPlatform.java
+++ b/linux/src/com/lightcrafts/platform/linux/LinuxPlatform.java
@@ -128,6 +128,7 @@ public class LinuxPlatform extends Platform {
         return Profiles;
     }
 
+    // See proposal notes
     @Override
     public int getPhysicalMemoryInMB() {
         final String osname = System.getProperty("os.name");

--- a/windows/BUILD-Windows-msys2.md
+++ b/windows/BUILD-Windows-msys2.md
@@ -23,6 +23,9 @@ Download and install (or unpack) following:
     1. Install __lcms2__. This will also install __libtiff__ and __libjpeg-turbo__.
     -    For 32-bit: `pacman -S mingw-w64-i686-lcms2`
     -    For 64-bit: `pacman -S mingw-w64-x86_64-lcms2`
+    1. Install __ntldd__.
+    -    For 32-bit: `pacman -S mingw-w64-i686-ntldd-git`
+    -    For 64-bit: `pacman -S mingw-w64-x86_64-ntldd-git`
 -   __Oracle JDK SE 8__ (Java Development Kit)
 -   __Microsoft Windows SDK__
     Pick the right version based on your Windows version. Information and download links are

--- a/windows/helpers/JavaAppLauncher/GNUmakefile
+++ b/windows/helpers/JavaAppLauncher/GNUmakefile
@@ -19,7 +19,7 @@ CFLAGS:=	-O3
 DEFINES:=	-D_WIN32_IE=0x0500 -D_WIN32_WINNT=0x0500 -DNTDDK_VERSION=0x05000200 -DUNICODE
 INCLUDES:=	-I"$(JAVA_HOME)/include" -I"$(JAVA_HOME)/include/win32" \
 		-I$(COMMON_DIR)/jnisrc/jniutils
-LDFLAGS:=	-mwindows -static-libgcc -static-libstdc++
+LDFLAGS:=	-mwindows
 LINK:=		-lshlwapi
 
 TARGET:=	LightZone.exe

--- a/windows/products/GNUmakefile
+++ b/windows/products/GNUmakefile
@@ -17,7 +17,7 @@ $(DEST_COMMON_PRODUCTS): FORCE
 	$(call SYMLINK,$(COMMON_DIR)/products/$@,$@)
 
 libs: $(DEST_COMMON_PRODUCTS)
-	$(shell ldd *.dll | grep -o "/.*mingw.*\.dll" | sort | uniq | xargs -r cp -u -t .)
+	$(shell ntldd *.dll | grep -o " => .*mingw.*\.dll" | sort | uniq | sed 's/ => \(.*\)/"\1"/g' | xargs -r cygpath | xargs -r cp -u -t .)
 
 .PHONY: FORCE
 FORCE:


### PR DESCRIPTION
It is possible to simply use the Management to get this information. You should not have to spin up processes and rely on specific text format output from certain commands to get to this information. Here's an example:

import java.lang.management.ManagementFactory;

import javax.management.AttributeNotFoundException;
import javax.management.InstanceNotFoundException;
import javax.management.MBeanException;
import javax.management.MBeanServer;
import javax.management.MalformedObjectNameException;
import javax.management.ObjectName;
import javax.management.ReflectionException;

public class Main {
  public static void main(String[] args) throws InstanceNotFoundException, AttributeNotFoundException, MalformedObjectNameException, ReflectionException, MBeanException  {
  /* Total number of processors or cores available to the JVM */


      MBeanServer mBeanServer = ManagementFactory.getPlatformMBeanServer();
      Object attribute = mBeanServer.getAttribute(new ObjectName("java.lang","type","OperatingSystem"), "TotalPhysicalMemorySize");
      Object attribute2 = mBeanServer.getAttribute(new ObjectName("java.lang","type","OperatingSystem"), "FreePhysicalMemorySize");
      System.out.println("Total memory: "+ Long.parseLong(attribute.toString()) / 1024  +"MB");
      System.out.println("Free  memory: "+ Long.parseLong(attribute2.toString()) / 1024  +"MB");    

 }
}