### PR TITLE
linux: fix broken ivy 2.4.0 link

### DIFF
--- a/lightcrafts/build.xml
+++ b/lightcrafts/build.xml
@@ -53,7 +53,7 @@
 
   <target name="download-ivy" unless="offline">
     <mkdir dir="${ivy.jar.dir}"/>
-    <get src="http://repo2.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"
+    <get src="https://repo1.maven.org/maven2/org/apache/ivy/ivy/${ivy.version}/ivy-${ivy.version}.jar"
          dest="${ivy.jar.file}" usetimestamp="true"/>
   </target>
 


### PR DESCRIPTION
The previous link responds with a 501