### PR TITLE
Fix UnsupportedOperationException in Red Eye tool

### DIFF
--- a/lightcrafts/src/com/lightcrafts/jai/opimage/RedMaskBlackener.java
+++ b/lightcrafts/src/com/lightcrafts/jai/opimage/RedMaskBlackener.java
@@ -1,14 +1,19 @@
 /* Copyright (C) 2005-2011 Fabio Riccardi */
+/* Copyright (C) 2021-     Masahiro Kitagawa */
 
 package com.lightcrafts.jai.opimage;
 
-import javax.media.jai.PointOpImage;
+import com.lightcrafts.jai.utils.OpImageUtil;
+
 import javax.media.jai.ImageLayout;
+import javax.media.jai.PointOpImage;
 import javax.media.jai.RasterAccessor;
 import javax.media.jai.RasterFormatTag;
-
-import java.awt.image.*;
 import java.awt.*;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.RenderedImage;
+import java.awt.image.WritableRaster;
 import java.util.Map;
 
 /**
@@ -35,7 +40,11 @@ public class RedMaskBlackener extends PointOpImage {
                                WritableRaster dest,
                                Rectangle destRect) {
         // Retrieve format tags.
-        RasterFormatTag[] formatTags = getFormatTags();
+        var formatTags = new RasterFormatTag[] {
+                OpImageUtil.getFormatTag(sources[0]),
+                OpImageUtil.getFormatTag(sources[1]),
+                OpImageUtil.getFormatTag(dest)
+        };
 
         RasterAccessor src = new RasterAccessor(sources[0], destRect,
                 formatTags[0],

--- a/lightcrafts/src/com/lightcrafts/jai/opimage/RedMaskOpImage.java
+++ b/lightcrafts/src/com/lightcrafts/jai/opimage/RedMaskOpImage.java
@@ -1,15 +1,17 @@
 /* Copyright (C) 2005-2011 Fabio Riccardi */
+/* Copyright (C) 2021-     Masahiro Kitagawa */
 
 package com.lightcrafts.jai.opimage;
 
-import javax.media.jai.PointOpImage;
+import com.lightcrafts.jai.utils.OpImageUtil;
+
 import javax.media.jai.ImageLayout;
+import javax.media.jai.PointOpImage;
 import javax.media.jai.RasterAccessor;
 import javax.media.jai.RasterFormatTag;
-
-import java.awt.image.*;
-import java.awt.color.ColorSpace;
 import java.awt.*;
+import java.awt.color.ColorSpace;
+import java.awt.image.*;
 import java.util.Map;
 
 /**
@@ -42,18 +44,22 @@ public class RedMaskOpImage extends PointOpImage {
     protected void computeRect(Raster[] sources,
                                WritableRaster dest,
                                Rectangle destRect) {
-        // Retrieve format tags.
-        RasterFormatTag[] formatTags = getFormatTags();
-
         Raster source = sources[0];
+
+        // Retrieve format tags.
+        var formatTags = new RasterFormatTag[] {
+                OpImageUtil.getFormatTag(source),
+                OpImageUtil.getFormatTag(dest)
+        };
+
         Rectangle srcRect = mapDestRect(destRect, 0);
 
         RasterAccessor src = new RasterAccessor(source, srcRect, formatTags[0],
                                                 getSourceImage(0).getColorModel());
         RasterAccessor dst = new RasterAccessor(dest, destRect, formatTags[1], getColorModel());
 
-        switch (dst.getDataType()) {
-            case DataBuffer.TYPE_BYTE:
+        switch (src.getDataType()) {
+            case DataBuffer.TYPE_USHORT:
                 ushortLoop(src, dst);
                 break;
             default:

--- a/lightcrafts/src/com/lightcrafts/jai/utils/OpImageUtil.java
+++ b/lightcrafts/src/com/lightcrafts/jai/utils/OpImageUtil.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2021. Masahiro Kitagawa
+ */
+
+package com.lightcrafts.jai.utils;
+
+import com.sun.media.jai.util.ImageUtil;
+import org.jetbrains.annotations.NotNull;
+
+import javax.media.jai.RasterFormatTag;
+import java.awt.image.ComponentSampleModel;
+import java.awt.image.DataBuffer;
+import java.awt.image.Raster;
+import java.awt.image.SampleModel;
+
+import static javax.media.jai.RasterAccessor.*;
+
+public final class OpImageUtil {
+    @NotNull
+    public static RasterFormatTag getFormatTag(@NotNull Raster raster) {
+        final var sm = raster.getSampleModel();
+        final int formatTagID = getFormatTagID(sm);
+        return new RasterFormatTag(sm, formatTagID);
+    }
+
+    // cf. javax.media.jai.RasterAccessor#findCompatibleTag
+    private static int getFormatTagID(@NotNull SampleModel sampleModel) {
+        int dataType = sampleModel.getTransferType();
+        final int tag;
+        if (sampleModel instanceof ComponentSampleModel) {
+            tag = dataType | UNCOPIED;
+        } else if (ImageUtil.isBinary(sampleModel)) {
+            tag = DataBuffer.TYPE_BYTE | COPIED;
+        } else if (dataType == DataBuffer.TYPE_BYTE ||
+                dataType == DataBuffer.TYPE_USHORT ||
+                dataType == DataBuffer.TYPE_SHORT) {
+            tag = TAG_INT_COPIED;
+        } else {
+            tag = dataType | COPIED;
+        }
+        return tag | UNEXPANDED;
+    }
+}


### PR DESCRIPTION
Fix Aries85/LightZone#259

Don't use the OpImage#getFormatTags here; It returns compatible
data type for sources and dests, and it always returns TYPE_INT (3)
when the source is TYPE_USHORT and mask is TYPE_BYTE.